### PR TITLE
alternate dynamic canon map methods

### DIFF
--- a/include/tinygraph.h
+++ b/include/tinygraph.h
@@ -36,7 +36,7 @@ TINY_GRAPH *TinyGraphComplement(TINY_GRAPH *Gbar, TINY_GRAPH *G);
 TINY_GRAPH *TinyGraphUnion(TINY_GRAPH *destination, TINY_GRAPH *G1, TINY_GRAPH *G2);
 int TinyGraphNumEdges(TINY_GRAPH *G); // total number of edges, just the sum of the degrees / 2.
 TINY_GRAPH *TinyGraphToUndirected(TINY_GRAPH *G, TINY_GRAPH *H);
-TINY_GRAPH *TinyGraphSortByDegree(TINY_GRAPH *G);
+TINY_GRAPH *TinyGraphSort(TINY_GRAPH *G, Boolean byCubedSum);
 #define TinyGraphDegree(G,v) ((G)->degree[v])
 
 /* Returns number of nodes in the the distance-d neighborhood, including seed.

--- a/src/tinygraph.c
+++ b/src/tinygraph.c
@@ -209,11 +209,22 @@ TINY_GRAPH *TinyGraphToUndirected(TINY_GRAPH *G, TINY_GRAPH *H)
     return H;
 }
 
-TINY_GRAPH *TinyGraphSortByDegree(TINY_GRAPH *G)
+TINY_GRAPH *TinyGraphSort(TINY_GRAPH *G, Boolean byCubedSum)
 {
     int i, j, n = G->n;
     for(i = 1; i < n; i++) {
         j = i;
+        if(byCubedSum) {
+            int sum = 0, sumPrev = 0;
+            for(int k = 0; k < n; k++) {
+                if(TinyGraphAreConnected(G, i, k)) sum += G->degree[k] * G->degree[k] * G->degree[k];
+                if(TinyGraphAreConnected(G, i-1, k)) sumPrev += G->degree[k] * G->degree[k] * G->degree[k];
+            }
+            while(j > 0 && sum < sumPrev) {
+                TinyGraphSwapNodes(G, j-1, j);
+                j--;
+            }
+        }
         while(j > 0 && G->degree[j] < G->degree[j-1]) {
             TinyGraphSwapNodes(G, j-1, j);
             j--;


### PR DESCRIPTION
Sort by sum of degree cubed over all neighbors of the node, rather than the degree of the node. Should be faster for larger k